### PR TITLE
[Bug]Fix internal server error when GC is triggered with forcemajor or forceminor

### DIFF
--- a/bookkeeper-http/vertx-http-server/src/main/java/org/apache/bookkeeper/http/vertx/VertxAbstractHandler.java
+++ b/bookkeeper-http/vertx-http-server/src/main/java/org/apache/bookkeeper/http/vertx/VertxAbstractHandler.java
@@ -33,11 +33,15 @@ import org.apache.bookkeeper.http.service.ErrorHttpService;
 import org.apache.bookkeeper.http.service.HttpEndpointService;
 import org.apache.bookkeeper.http.service.HttpServiceRequest;
 import org.apache.bookkeeper.http.service.HttpServiceResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Http Handler for Vertx based Http Server.
  */
 public abstract class VertxAbstractHandler implements Handler<RoutingContext> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VertxAbstractHandler.class);
 
     /**
      * Process the request using the given httpEndpointService.
@@ -53,6 +57,7 @@ public abstract class VertxAbstractHandler implements Handler<RoutingContext> {
         try {
             response = httpEndpointService.handle(request);
         } catch (Exception e) {
+            LOG.error("Failed to execute http request:", e);
             response = new ErrorHttpService().handle(request);
         }
         httpResponse.setStatusCode(response.getStatusCode());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ResumeCompactionService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ResumeCompactionService.java
@@ -53,18 +53,25 @@ public class ResumeCompactionService implements HttpEndpointService {
             } else {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> configMap = JsonUtil.fromJson(requestBody, HashMap.class);
-                Boolean resumeMajor = (Boolean) configMap.get("resumeMajor");
-                Boolean resumeMinor = (Boolean) configMap.get("resumeMinor");
-                if (resumeMajor == null && resumeMinor == null) {
+                Object resumeMajorObj = configMap.get("resumeMajor");
+                Object resumeMinorObj = configMap.get("resumeMinor");
+                boolean resumeMajor = false, resumeMinor = false;
+                if (resumeMajorObj instanceof Boolean) {
+                    resumeMajor = (Boolean) resumeMajorObj;
+                }
+                if (resumeMinorObj instanceof Boolean) {
+                    resumeMinor = (Boolean) resumeMinorObj;
+                }
+                if (!resumeMajor && !resumeMinor) {
                     return new HttpServiceResponse("No resumeMajor or resumeMinor params found",
                             HttpServer.StatusCode.BAD_REQUEST);
                 }
                 String output = "";
-                if (resumeMajor != null  && resumeMajor) {
+                if (resumeMajor) {
                     output = "Resume majorGC on BookieServer: " + bookieServer.toString();
                     bookieServer.getBookie().getLedgerStorage().resumeMajorGC();
                 }
-                if (resumeMinor != null && resumeMinor) {
+                if (resumeMinor) {
                     output += ", Resume minorGC on BookieServer: " + bookieServer.toString();
                     bookieServer.getBookie().getLedgerStorage().resumeMinorGC();
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/SuspendCompactionService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/SuspendCompactionService.java
@@ -53,18 +53,26 @@ public class SuspendCompactionService implements HttpEndpointService {
             } else {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> configMap = JsonUtil.fromJson(requestBody, HashMap.class);
-                Boolean suspendMajor = (Boolean) configMap.get("suspendMajor");
-                Boolean suspendMinor = (Boolean) configMap.get("suspendMinor");
-                if (suspendMajor == null && suspendMinor == null) {
+                Object suspendMajorObj = configMap.get("suspendMajor");
+                Object suspendMinorObj = configMap.get("suspendMinor");
+                boolean suspendMajor = false, suspendMinor = false;
+                if (suspendMajorObj instanceof Boolean) {
+                    suspendMajor = (Boolean) suspendMajorObj;
+                }
+                if (suspendMinorObj instanceof Boolean) {
+                    suspendMinor = (Boolean) suspendMinorObj;
+                }
+
+                if (!suspendMajor && !suspendMinor) {
                     return new HttpServiceResponse("No suspendMajor or suspendMinor params found",
                             HttpServer.StatusCode.BAD_REQUEST);
                 }
                 String output = "";
-                if (suspendMajor != null  && suspendMajor) {
+                if (suspendMajor) {
                     output = "Suspend majorGC on BookieServer: " + bookieServer.toString();
                     bookieServer.getBookie().getLedgerStorage().suspendMajorGC();
                 }
-                if (suspendMinor != null && suspendMinor) {
+                if (suspendMinor) {
                     output += ", Suspend minorGC on BookieServer: " + bookieServer.toString();
                     bookieServer.getBookie().getLedgerStorage().suspendMinorGC();
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerGCService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerGCService.java
@@ -69,8 +69,15 @@ public class TriggerGCService implements HttpEndpointService {
             } else {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> configMap = JsonUtil.fromJson(requestBody, HashMap.class);
-                Boolean forceMajor = (Boolean) configMap.getOrDefault("forceMajor", null);
-                Boolean forceMinor = (Boolean) configMap.getOrDefault("forceMinor", null);
+                Object forceMajorObj = configMap.getOrDefault("forceMajor", null);
+                Object forceMinorObj = configMap.getOrDefault("forceMinor", null);
+                boolean forceMajor = false, forceMinor = false;
+                if (forceMajorObj instanceof Boolean) {
+                    forceMajor = (Boolean) forceMajorObj;
+                }
+                if (forceMinorObj instanceof Boolean) {
+                    forceMinor = (Boolean) forceMinorObj;
+                }
                 bookieServer.getBookie().getLedgerStorage().forceGC(forceMajor, forceMinor);
             }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerLocationCompactService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerLocationCompactService.java
@@ -83,9 +83,17 @@ public class TriggerLocationCompactService implements HttpEndpointService {
             try {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> configMap = JsonUtil.fromJson(requestBody, HashMap.class);
-                Boolean isEntryLocationCompact = (Boolean) configMap
-                        .getOrDefault("entryLocationRocksDBCompact", false);
-                String entryLocations = (String) configMap.getOrDefault("entryLocations", "");
+                Object isEntryLocationCompactObj = configMap
+                        .get("entryLocationRocksDBCompact");
+                boolean isEntryLocationCompact = false;
+                if (isEntryLocationCompactObj instanceof Boolean) {
+                    isEntryLocationCompact = (Boolean) isEntryLocationCompactObj;
+                }
+                Object entryLocationsObj = configMap.get("entryLocations");
+                String entryLocations = "";
+                if (entryLocationsObj instanceof String) {
+                    entryLocations = (String) entryLocationsObj;
+                }
 
                 if (!isEntryLocationCompact) {
                     // If entryLocationRocksDBCompact is false, doing nothing.

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/ResumeCompactionServiceTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/ResumeCompactionServiceTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.server.http.service;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+import org.apache.bookkeeper.common.util.JsonUtil;
+import org.apache.bookkeeper.http.HttpServer;
+import org.apache.bookkeeper.http.service.HttpServiceRequest;
+import org.apache.bookkeeper.http.service.HttpServiceResponse;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ResumeCompactionServiceTest extends BookKeeperClusterTestCase {
+
+    private static final int numberOfBookies = 1;
+    private SuspendCompactionService suspendCompactionService;
+    private ResumeCompactionService resumeCompactionService;
+
+    public ResumeCompactionServiceTest() {
+        super(numberOfBookies);
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        resumeCompactionService = new ResumeCompactionService(serverByIndex(numBookies - 1));
+        suspendCompactionService = new SuspendCompactionService(serverByIndex(numBookies - 1));
+    }
+
+    @Test
+    public void testResumeCompactionWithBadMajorAndMinorCompactArgs() throws Exception {
+        String triggerResumeBody = "{ \"resumeMajor\": \"true\", \"resumeMinor\": \"true\" }";
+        HttpServiceRequest resumeRequest = new HttpServiceRequest(triggerResumeBody, HttpServer.Method.PUT, null);
+        HttpServiceResponse response = resumeCompactionService.handle(resumeRequest);
+        assertEquals(HttpServer.StatusCode.BAD_REQUEST.getValue(), response.getStatusCode());
+    }
+
+    @Test
+    public void testResumeCompactionWithBadMajorAndGoodMinorCompactArgs() throws Exception {
+        String triggerSuspendBody = "{ \"suspendMajor\": true, \"suspendMinor\": true }";
+        String triggerResumeBody = "{ \"resumeMajor\": \"true\", \"resumeMinor\": true }";
+        HttpServiceRequest suspendRequest = new HttpServiceRequest(triggerSuspendBody, HttpServer.Method.PUT, null);
+        suspendCompactionService.handle(suspendRequest);
+        Map beforeResumeStatusResponseMap = getCompactionStatus();
+        assertEquals("true", beforeResumeStatusResponseMap.get("isMajorGcSuspended"));
+        assertEquals("true", beforeResumeStatusResponseMap.get("isMinorGcSuspended"));
+        HttpServiceRequest resumeRequest = new HttpServiceRequest(triggerResumeBody, HttpServer.Method.PUT, null);
+        HttpServiceResponse response = resumeCompactionService.handle(resumeRequest);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response.getStatusCode());
+        Map afterResumeStatusResponseMap = getCompactionStatus();
+        assertEquals("true", afterResumeStatusResponseMap.get("isMajorGcSuspended"));
+        assertEquals("false", afterResumeStatusResponseMap.get("isMinorGcSuspended"));
+    }
+
+    @Test
+    public void testResumeCompactionWithGoodMajorAndBadMinorCompactArgs() throws Exception {
+        String triggerSuspendBody = "{ \"suspendMajor\": true, \"suspendMinor\": true }";
+        String triggerResumeBody = "{ \"resumeMajor\": true, \"resumeMinor\": \"true\" }";
+        HttpServiceRequest suspendRequest = new HttpServiceRequest(triggerSuspendBody, HttpServer.Method.PUT, null);
+        suspendCompactionService.handle(suspendRequest);
+        Map beforeResumeStatusResponseMap = getCompactionStatus();
+        assertEquals("true", beforeResumeStatusResponseMap.get("isMajorGcSuspended"));
+        assertEquals("true", beforeResumeStatusResponseMap.get("isMinorGcSuspended"));
+        HttpServiceRequest resumeRequest = new HttpServiceRequest(triggerResumeBody, HttpServer.Method.PUT, null);
+        HttpServiceResponse response = resumeCompactionService.handle(resumeRequest);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response.getStatusCode());
+        Map afterResumeStatusResponseMap = getCompactionStatus();
+        assertEquals("false", afterResumeStatusResponseMap.get("isMajorGcSuspended"));
+        assertEquals("true", afterResumeStatusResponseMap.get("isMinorGcSuspended"));
+    }
+
+    private Map getCompactionStatus() throws Exception {
+        HttpServiceRequest statusRequest = new HttpServiceRequest(null, HttpServer.Method.GET, null);
+        HttpServiceResponse statusResponse = suspendCompactionService.handle(statusRequest);
+        return JsonUtil.fromJson(statusResponse.getBody(), Map.class);
+    }
+
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/SuspendCompactionServiceTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/SuspendCompactionServiceTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.server.http.service;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+import org.apache.bookkeeper.common.util.JsonUtil;
+import org.apache.bookkeeper.http.HttpServer;
+import org.apache.bookkeeper.http.service.HttpServiceRequest;
+import org.apache.bookkeeper.http.service.HttpServiceResponse;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SuspendCompactionServiceTest extends BookKeeperClusterTestCase {
+
+    private static final int numberOfBookies = 1;
+    private SuspendCompactionService suspendCompactionService;
+
+    public SuspendCompactionServiceTest() {
+        super(numberOfBookies);
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        suspendCompactionService = new SuspendCompactionService(serverByIndex(numBookies - 1));
+    }
+
+    @Test
+    public void testSuspendCompactionWithBadMajorAndMinorCompactArgs() throws Exception {
+        String testBody = "{ \"suspendMajor\": \"true\", \"suspendMinor\": \"true\" }";
+        Map beforeStatusResponseMap = getCompactionStatus();
+        assertEquals("false", beforeStatusResponseMap.get("isMajorGcSuspended"));
+        assertEquals("false", beforeStatusResponseMap.get("isMinorGcSuspended"));
+        HttpServiceRequest suspendRequest = new HttpServiceRequest(testBody, HttpServer.Method.PUT, null);
+        HttpServiceResponse response = suspendCompactionService.handle(suspendRequest);
+        assertEquals(HttpServer.StatusCode.BAD_REQUEST.getValue(), response.getStatusCode());
+
+    }
+
+    @Test
+    public void testSuspendCompactionWithBadMajorAndGoodMinorCompactArgs() throws Exception {
+        String testBody = "{ \"suspendMajor\": \"true\", \"suspendMinor\": true }";
+        Map beforeStatusResponseMap = getCompactionStatus();
+        assertEquals("false", beforeStatusResponseMap.get("isMajorGcSuspended"));
+        assertEquals("false", beforeStatusResponseMap.get("isMinorGcSuspended"));
+        HttpServiceRequest suspendRequest = new HttpServiceRequest(testBody, HttpServer.Method.PUT, null);
+        HttpServiceResponse response = suspendCompactionService.handle(suspendRequest);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response.getStatusCode());
+        Map afterStatusResponseMap = getCompactionStatus();
+        assertEquals("false", afterStatusResponseMap.get("isMajorGcSuspended"));
+        assertEquals("true", afterStatusResponseMap.get("isMinorGcSuspended"));
+    }
+
+    @Test
+    public void testSuspendCompactionWithGoodMajorAndBadMinorCompactArgs() throws Exception {
+        String testBody = "{ \"suspendMajor\": true, \"suspendMinor\": \"true\" }";
+        Map beforeStatusResponseMap = getCompactionStatus();
+        assertEquals("false", beforeStatusResponseMap.get("isMajorGcSuspended"));
+        assertEquals("false", beforeStatusResponseMap.get("isMinorGcSuspended"));
+        HttpServiceRequest suspendRequest = new HttpServiceRequest(testBody, HttpServer.Method.PUT, null);
+        HttpServiceResponse response = suspendCompactionService.handle(suspendRequest);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response.getStatusCode());
+        Map afterStatusResponseMap = getCompactionStatus();
+        assertEquals("true", afterStatusResponseMap.get("isMajorGcSuspended"));
+        assertEquals("false", afterStatusResponseMap.get("isMinorGcSuspended"));
+    }
+
+    private Map getCompactionStatus() throws Exception {
+        HttpServiceRequest statusRequest = new HttpServiceRequest(null, HttpServer.Method.GET, null);
+        HttpServiceResponse statusResponse = suspendCompactionService.handle(statusRequest);
+        return JsonUtil.fromJson(statusResponse.getBody(), Map.class);
+    }
+
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/TriggerGCServiceTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/TriggerGCServiceTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.server.http.service;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.apache.bookkeeper.bookie.GarbageCollectionStatus;
+import org.apache.bookkeeper.http.HttpServer;
+import org.apache.bookkeeper.http.service.HttpServiceRequest;
+import org.apache.bookkeeper.http.service.HttpServiceResponse;
+import org.apache.bookkeeper.proto.BookieServer;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TriggerGCServiceTest extends BookKeeperClusterTestCase {
+
+    private static final int numberOfBookies = 1;
+    private TriggerGCService triggerGCService;
+
+    public TriggerGCServiceTest() {
+        super(numberOfBookies);
+    }
+
+    private List<GarbageCollectionStatus> getGCCollectionStats() throws Exception {
+        assertEquals(1, bookieCount());
+        BookieServer server = serverByIndex(0);
+        return server.getBookie().getLedgerStorage().getGarbageCollectionStatus();
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        triggerGCService = new TriggerGCService(baseConf, serverByIndex(numBookies - 1));
+    }
+
+    @Test
+    public void testGCTriggerSuccessWithForceMajorAndMinorCompact() throws Exception {
+        String testBody = "{ \"forceMajor\": true, \"forceMinor\": true }";
+        HttpServiceRequest request = new HttpServiceRequest(testBody, HttpServer.Method.PUT, null);
+        long majorCompactionCounterBeforeTrigger = getGCCollectionStats().get(0).getMajorCompactionCounter();
+        long minorCompactionCounterBeforeTrigger = getGCCollectionStats().get(0).getMinorCompactionCounter();
+        HttpServiceResponse httpServiceResponse = triggerGCService.handle(request);
+        while (serverByIndex(numBookies - 1).getBookie().getLedgerStorage().isInForceGC()) {
+            Thread.sleep(1000);
+        }
+        long majorCompactionCounterAfterTrigger = getGCCollectionStats().get(0).getMajorCompactionCounter();
+        long minorCompactionCounterAfterTrigger = getGCCollectionStats().get(0).getMinorCompactionCounter();
+        assertEquals(majorCompactionCounterBeforeTrigger + 1, majorCompactionCounterAfterTrigger);
+        assertEquals(minorCompactionCounterBeforeTrigger, minorCompactionCounterAfterTrigger);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), httpServiceResponse.getStatusCode());
+    }
+
+    @Test
+    public void testGCTriggerSuccessWithForceMajorCompactOnly() throws Exception {
+        String testBody = "{ \"forceMajor\": true, \"forceMinor\": false }";
+        HttpServiceRequest request = new HttpServiceRequest(testBody, HttpServer.Method.PUT, null);
+        long majorCompactionCounterBeforeTrigger = getGCCollectionStats().get(0).getMajorCompactionCounter();
+        long minorCompactionCounterBeforeTrigger = getGCCollectionStats().get(0).getMinorCompactionCounter();
+        HttpServiceResponse httpServiceResponse = triggerGCService.handle(request);
+        while (serverByIndex(numBookies - 1).getBookie().getLedgerStorage().isInForceGC()) {
+            Thread.sleep(1000);
+        }
+        long majorCompactionCounterAfterTrigger = getGCCollectionStats().get(0).getMajorCompactionCounter();
+        long minorCompactionCounterAfterTrigger = getGCCollectionStats().get(0).getMinorCompactionCounter();
+        assertEquals(majorCompactionCounterBeforeTrigger + 1, majorCompactionCounterAfterTrigger);
+        assertEquals(minorCompactionCounterBeforeTrigger, minorCompactionCounterAfterTrigger);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), httpServiceResponse.getStatusCode());
+    }
+
+    @Test
+    public void testGCTriggerSuccessWithForceMinorCompactOnly() throws Exception {
+        String testBody = "{ \"forceMajor\": false, \"forceMinor\": true }";
+        HttpServiceRequest request = new HttpServiceRequest(testBody, HttpServer.Method.PUT, null);
+        long majorCompactionCounterBeforeTrigger = getGCCollectionStats().get(0).getMajorCompactionCounter();
+        long minorCompactionCounterBeforeTrigger = getGCCollectionStats().get(0).getMinorCompactionCounter();
+        HttpServiceResponse httpServiceResponse = triggerGCService.handle(request);
+        while (serverByIndex(numBookies - 1).getBookie().getLedgerStorage().isInForceGC()) {
+            Thread.sleep(1000);
+        }
+        long majorCompactionCounterAfterTrigger = getGCCollectionStats().get(0).getMajorCompactionCounter();
+        long minorCompactionCounterAfterTrigger = getGCCollectionStats().get(0).getMinorCompactionCounter();
+        assertEquals(majorCompactionCounterBeforeTrigger, majorCompactionCounterAfterTrigger);
+        assertEquals(minorCompactionCounterBeforeTrigger + 1, minorCompactionCounterAfterTrigger);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), httpServiceResponse.getStatusCode());
+    }
+
+    @Test
+    public void testGCTriggerSuccessWithBadRequestBody() throws Exception {
+        String testBody = "{ \"forceMajor\": \"true\", \"forceMinor\": [true] }";
+        HttpServiceRequest request = new HttpServiceRequest(testBody, HttpServer.Method.PUT, null);
+        long majorCompactionCounterBeforeTrigger = getGCCollectionStats().get(0).getMajorCompactionCounter();
+        long minorCompactionCounterBeforeTrigger = getGCCollectionStats().get(0).getMinorCompactionCounter();
+        HttpServiceResponse httpServiceResponse = triggerGCService.handle(request);
+        while (serverByIndex(numBookies - 1).getBookie().getLedgerStorage().isInForceGC()) {
+            Thread.sleep(1000);
+        }
+        long majorCompactionCounterAfterTrigger = getGCCollectionStats().get(0).getMajorCompactionCounter();
+        long minorCompactionCounterAfterTrigger = getGCCollectionStats().get(0).getMinorCompactionCounter();
+        assertEquals(majorCompactionCounterBeforeTrigger, majorCompactionCounterAfterTrigger);
+        assertEquals(minorCompactionCounterBeforeTrigger, minorCompactionCounterAfterTrigger);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), httpServiceResponse.getStatusCode());
+    }
+
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/TriggerLocationCompactServiceTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/TriggerLocationCompactServiceTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.server.http.service;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.bookkeeper.http.HttpServer;
+import org.apache.bookkeeper.http.service.HttpServiceRequest;
+import org.apache.bookkeeper.http.service.HttpServiceResponse;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class TriggerLocationCompactServiceTest extends BookKeeperClusterTestCase {
+
+    private static final int numberOfBookies = 1;
+    private TriggerLocationCompactService triggerLocationCompactService;
+
+    public TriggerLocationCompactServiceTest() {
+        super(numberOfBookies);
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        triggerLocationCompactService = new TriggerLocationCompactService(serverByIndex(numBookies - 1));
+    }
+
+    @Test
+    public void testTriggerLocationCompactServiceWithBadEntryLocationCompactFlag() throws Exception {
+        String testBody = "{ \"entryLocationRocksDBCompact\": \"true\" }";
+        String expectedOutput = "Not trigger Entry Location RocksDB compact.";
+        HttpServiceRequest request = new HttpServiceRequest(testBody, HttpServer.Method.PUT, null);
+        HttpServiceResponse response = triggerLocationCompactService.handle(request);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response.getStatusCode());
+        assertEquals(expectedOutput, response.getBody());
+    }
+
+}


### PR DESCRIPTION


Descriptions of the changes in this PR:
This PR fixes the internal server error when the GC is triggered via the REST API. The reason this error occurs is because the code is trying to perform a String to boolean casting which is failing.
The code change is to make this conversion work.


### Motivation
Fixes #3845 

### Changes

Modified the code to perform a safer string to boolean conversion when trying to find the values in the JSON payload. Also converted the map from a <String, Object> to <String, String>.

Master Issue: #3845 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
